### PR TITLE
fix: read file failed on android 10 and above without requestLegacyExternalStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.1.1-dev",
+  "version": "4.2.1",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.1.1-dev">
+    version="4.2.1">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -686,7 +686,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         int rotate = 0;
 
-        String fileLocation = FileHelper.getRealPath(uri, this.cordova);
+        String fileLocation = null;
+
+        try {
+            fileLocation = FileHelper.getRealPath(uri, this.cordova);
+        } catch (IOException e) {
+            this.failPicture(e.getMessage());
+        }
+
         LOG.d(LOG_TAG, "File location is: " + fileLocation);
 
         String uriString = uri.toString();

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -291,6 +291,13 @@ public class FileHelper {
                 final int column_index = cursor.getColumnIndexOrThrow(column);
                 return cursor.getString(column_index);
             }
+        } catch (SecurityException e){
+            // https://stackoverflow.com/questions/54587884/java-lang-securityexception-permission-denial-opening-provider-com-estrongs-an
+            if (uri.toString().contains("/storage/emulated/0")) {
+                return "/storage/emulated/0" + uri.toString().split("/storage/emulated/0")[1];
+            } else {
+                return null;
+            }
         } catch (Exception e) {
             return null;
         } finally {
@@ -372,7 +379,7 @@ public class FileHelper {
                     final int indexDisplayName = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME);
                     final int indexSize = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE);
                     long fileSize = cursor.getLong(indexSize);
-                    if (fileSize > 500 * 1024 * 1024){
+                    if (fileSize > 2 * 1024 * 1024 * 1024L){
                         // copy file is a heavy operation. limit file size here to ensure performance and avoid OOM.
                         throw new IOException("SELECTED_FILE_TOO_LARGE");
                     }


### PR DESCRIPTION
Due to [Api 29+ Behavior changes](https://developer.android.com/about/versions/10/behavior-changes-all), The scoped storage should fixed.
The pull request aims to fix read file failed without announces `android:requestLegacyExternalStorage` flag.
When Api level gte 29. The behavior fallback to copy file to temp dir and return temp file back.

References: 
https://github.com/ivpusic/react-native-image-crop-picker/blob/798ac61cf94c393bea833f1b583bbfba7a09c6ea/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java#L138
https://github.com/hiddentao/cordova-plugin-filepath/blob/7b8847e0b182c2a1f427a31f3b04f40e11842144/src/android/FilePath.java#L420

Related: https://github.com/apache/cordova-plugin-camera/pull/585, https://github.com/apache/cordova-plugin-camera/issues/573, https://github.com/apache/cordova-plugin-camera/issues/531, https://github.com/apache/cordova-plugin-camera/issues/548, https://github.com/apache/cordova-plugin-camera/issues/554, https://github.com/apache/cordova-plugin-camera/issues/558, https://github.com/apache/cordova-plugin-camera/issues/563